### PR TITLE
修正 `lue` 和 `nue`

### DIFF
--- a/src/clover.schema.yaml
+++ b/src/clover.schema.yaml
@@ -98,7 +98,7 @@ speller:
     - derive/^ding$/din/     # din = ding
     
     # 处理 v 和 u
-    - derive/^([nl])ue$/$1ve/   # nve = nue; lve = lue
+    - derive/^([nl])ve$/$1ue/   # nue = nve; lue = lve
     - derive/^([jqxy])u/$1v/    # v = u; v = u
     
     # 智能纠错


### PR DESCRIPTION
字典`clover.base.dict.yaml`里“略”等字的拼音为`lve`：
```
略  lve 174000
```
因此`clover.schema.yaml`中应把`lue`等同于`lve`（即从`lve`衍生`lue`），而不是反过来；`nue`同理。

相对的，这一行不需要修改：
https://github.com/so1ar/rime-cloverpinyin/blob/cd269de35fdf460432e4922ff3a37ac5e1a87a97/src/clover.schema.yaml#L102
因为字典中“据”等字的拼音为`ju`：
```
据  ju  1771049
```
因此目前把`jv`等同于`ju`是正确的。

相关 issue：fkxxyz/rime-cloverpinyin#94